### PR TITLE
Allow telling whether an Operation specifies `security`

### DIFF
--- a/src/OpenApi/Operation.elm
+++ b/src/OpenApi/Operation.elm
@@ -135,8 +135,12 @@ deprecated (Operation operation_) =
     operation_.deprecated
 
 
-{-| -}
-security : Operation -> List SecurityRequirement
+{-| SecurityRequirements the operation specifies (possibly an empty list), or Nothing if the operation does not specify any.
+
+If an operation specifies `security`, the given value (even if it's an empty array) overrides the schema's top-level `security`. This is documented in the OpenAPI specification here: <https://swagger.io/specification/v3/#operation-object>.
+
+-}
+security : Operation -> Maybe (List SecurityRequirement)
 security (Operation operation_) =
     operation_.security
 

--- a/tests/Test/OpenApi/Operation.elm
+++ b/tests/Test/OpenApi/Operation.elm
@@ -71,6 +71,11 @@ suite =
                 decodedOperation
                     |> Result.map (OpenApi.Operation.security >> Maybe.map List.length)
                     |> Expect.equal (Ok (Just 1))
+        , test "security = []" <|
+            \() ->
+                Json.Decode.decodeString OpenApi.Operation.decode securityIsEmptyArrayExample
+                    |> Result.map OpenApi.Operation.security
+                    |> Expect.equal (Ok (Just []))
         , describe "when 'security' is unspecified" <|
             [ test "it decodes to Nothing" <|
                 \() ->
@@ -160,6 +165,21 @@ example =
       ]
     }
   ]
+}"""
+
+
+securityIsEmptyArrayExample : String
+securityIsEmptyArrayExample =
+    """{
+  "summary": "Updates a pet in the store with form data",
+  "operationId": "updatePetWithForm",
+  "security": [],
+  "responses": {
+    "200": {
+      "description": "Pet updated.",
+      "content": {}
+    }
+  }
 }"""
 
 


### PR DESCRIPTION
When an operation does not include the `security` key, it means "use the value of the top-level `security` key." When an operation *does* specify `security`, its value overrides the top-level `security` value. We need to be able to tell these cases apart in order to support operations overriding the global security setting.

Here's how the spec documents this, in its description of the `security` field, at https://swagger.io/specification/v3/#operation-object:

> A declaration of which security mechanisms can be used for this operation. [...] This definition overrides any declared top-level security. To remove a top-level security declaration, an empty array can be used.
